### PR TITLE
replace RunHiddenConsole.exe with CreateNoWindow on processstartinfo

### DIFF
--- a/VanillaLauncher/Vanilla.Designer.cs
+++ b/VanillaLauncher/Vanilla.Designer.cs
@@ -895,6 +895,7 @@ namespace VanillaLauncher
             this.Name = "Vanilla";
             this.Text = "Vanilla";
             this.Load += new System.EventHandler(this.Form1_Load);
+            this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.Vanilla_FormClosing);
             this.tabControl1.ResumeLayout(false);
             this.tabPage1.ResumeLayout(false);
             this.tabPage1.PerformLayout();

--- a/VanillaLauncher/Vanilla.Designer.cs
+++ b/VanillaLauncher/Vanilla.Designer.cs
@@ -895,7 +895,6 @@ namespace VanillaLauncher
             this.Name = "Vanilla";
             this.Text = "Vanilla";
             this.Load += new System.EventHandler(this.Form1_Load);
-            this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.Vanilla_FormClosing);
             this.tabControl1.ResumeLayout(false);
             this.tabPage1.ResumeLayout(false);
             this.tabPage1.PerformLayout();

--- a/VanillaLauncher/Vanilla.cs
+++ b/VanillaLauncher/Vanilla.cs
@@ -113,6 +113,7 @@ namespace VanillaLauncher
             {
                 FileName = "php-cgi.exe",
                 WorkingDirectory = Directory.GetCurrentDirectory() + "\\php",
+                Arguments = "-b 127.0.0.1:9123",
                 UseShellExecute = false,
                 CreateNoWindow = true
             });

--- a/VanillaLauncher/Vanilla.cs
+++ b/VanillaLauncher/Vanilla.cs
@@ -83,7 +83,7 @@ namespace VanillaLauncher
 
         private DarkModeCS DM = null;
         
-        private Timer timer = new Timer { Interval = 10 };
+        private Timer timer = new Timer { Interval = 100 }; // valley: this needs debating... for now it works
         private Process phpCGIProcess = new Process
         {
             StartInfo =
@@ -95,11 +95,6 @@ namespace VanillaLauncher
                 CreateNoWindow = true
             }
         };
-
-        private void Vanilla_FormClosing(object sender, FormClosingEventArgs e)
-        {
-            timer.Stop();
-        }
         
         public Vanilla()
         {
@@ -433,7 +428,7 @@ namespace VanillaLauncher
         }
         public void onshutdown(object sender, EventArgs e)
         {
-
+            timer.Stop();
             if (File.Exists("files\\settings.json"))
             {
                 File.Delete("files\\settings.json");

--- a/VanillaLauncher/Vanilla.cs
+++ b/VanillaLauncher/Vanilla.cs
@@ -83,7 +83,7 @@ namespace VanillaLauncher
 
         private DarkModeCS DM = null;
         
-        private Timer timer = new Timer { Interval = 100 };
+        private Timer timer = new Timer { Interval = 10 };
         private Process phpCGIProcess = new Process
         {
             StartInfo =

--- a/VanillaLauncher/Vanilla.cs
+++ b/VanillaLauncher/Vanilla.cs
@@ -95,7 +95,6 @@ namespace VanillaLauncher
             bool administrativeMode2 = principal.IsInRole(WindowsBuiltInRole.Administrator);
                 Process.Start("taskkill.exe", "/F /IM nginx.exe");
                 Process.Start("taskkill.exe", "/F /IM php-cgi.exe");
-                Process.Start("taskkill.exe", "/F /IM RunHiddenConsole.exe");
                 System.Threading.Thread.Sleep(3000);
                 string httpdconf = File.ReadAllText("files\\webserver\\conf\\nginx.conf");
                 string CurrentDirFixed = Directory.GetCurrentDirectory().Replace(@"\", @"/");
@@ -109,8 +108,14 @@ namespace VanillaLauncher
                     string fixedconf = httpdconf.Replace(@"C:/Vanilla/files/webroot", CurrentDirFixed + @"/files/webroot");
                     File.WriteAllText("files\\webserver\\conf\\nginx.conf", fixedconf);
                 }
-            Process.Start("files\\webserver\\php\\RunHiddenConsole.exe", "/r " + Directory.GetCurrentDirectory() + "\\files\\webserver\\php\\php-cgi.exe -b 127.0.0.1:9123");
             Directory.SetCurrentDirectory(Directory.GetCurrentDirectory() + "\\files\\webserver\\");
+            Process.Start(new ProcessStartInfo
+            {
+                FileName = "php-cgi.exe",
+                WorkingDirectory = Directory.GetCurrentDirectory() + "\\php",
+                UseShellExecute = false,
+                CreateNoWindow = true
+            });
             Process.Start(Directory.GetCurrentDirectory() + "\\nginx.exe");
             Directory.SetCurrentDirectory("..\\..");
             if (!administrativeMode)
@@ -446,7 +451,6 @@ namespace VanillaLauncher
             // don't use file.replace here or it'll cause issues
             File.Delete(hostsFile);
             File.Copy(hostsFile + ".bak", hostsFile);
-            Process.Start("CMD.exe", "/C taskkill /f /im RunHiddenConsole.exe");
             Process.Start("CMD.exe", "/C taskkill /F /IM nginx.exe");
             Process.Start("CMD.exe", "/C taskkill /F /IM php-cgi.exe");
 


### PR DESCRIPTION
basically removes the need for runhiddenconsole as it's hacky. needs testing but should do for 0.9.2 once it releases

eventually ill replace the way that processes get launched with a better solution once i get vs2019 working:
- nginx and php-cgi get launched on seperate process variables like `nginxProcess` and `phpCGIProcess`

and taskkill (makes concerning cmd windows) with this:
- nginx will be stopped with another process with same filename and directory BUT uses `-s quit`
- php-cgi will get killed with `Process.Kill()`